### PR TITLE
feat: Standardize on enterprise branding inheritance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+.astro/
+.DS_Store

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,0 +1,51 @@
+// @ts-check
+import { defineConfig } from 'astro/config';
+import starlight from '@astrojs/starlight';
+
+// Enterprise sidebar links - consistent jbcom branding
+const enterpriseSidebarLinks = {
+  label: 'jbcom Enterprise',
+  items: [
+    { label: 'jbcom Hub', link: 'https://jbcom.github.io', attrs: { target: '_blank' } },
+    { label: 'Agentic (AI)', link: 'https://agentic.dev', attrs: { target: '_blank' } },
+    { label: 'Strata (3D)', link: 'https://strata.game', attrs: { target: '_blank' } },
+    { label: 'Extended Data', link: 'https://extendeddata.dev', attrs: { target: '_blank' } },
+  ],
+};
+
+export default defineConfig({
+  site: 'https://arcade-cabinet.github.io',
+  integrations: [
+    starlight({
+      title: 'Arcade Cabinet',
+      description: 'Retro-inspired games and interactive experiences',
+      customCss: ['./src/styles/custom.css'],
+      social: [
+        { icon: 'github', label: 'GitHub', href: 'https://github.com/arcade-cabinet' },
+      ],
+      head: [
+        { tag: 'meta', attrs: { property: 'og:site_name', content: 'jbcom Enterprise' } },
+        { tag: 'meta', attrs: { name: 'author', content: 'Jon Bogaty' } },
+      ],
+      sidebar: [
+        {
+          label: 'Getting Started',
+          items: [
+            { label: 'Introduction', link: '/getting-started/' },
+          ],
+        },
+        {
+          label: 'Games',
+          autogenerate: { directory: 'games' },
+        },
+        {
+          label: 'Packages',
+          autogenerate: { directory: 'packages' },
+        },
+        enterpriseSidebarLinks,
+      ],
+      credits: true,
+      lastUpdated: true,
+    }),
+  ],
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "arcade-cabinet-docs",
+  "type": "module",
+  "version": "1.0.0",
+  "scripts": {
+    "dev": "astro dev",
+    "start": "astro dev",
+    "build": "astro build",
+    "preview": "astro preview"
+  },
+  "dependencies": {
+    "@astrojs/starlight": "^0.37.1",
+    "astro": "^5.6.1",
+    "sharp": "^0.34.2"
+  }
+}

--- a/src/content/docs/getting-started/index.md
+++ b/src/content/docs/getting-started/index.md
@@ -1,0 +1,18 @@
+---
+title: Getting Started
+description: Get started with Arcade Cabinet games
+---
+
+# Getting Started
+
+Welcome to Arcade Cabinet! This is the home for retro-inspired games and interactive experiences.
+
+## Available Games
+
+- **Protocol: Silent Night** - Stealth action
+- **Otter River Rush** - River racing
+- **Realm Walker** - Adventure exploration
+
+## Part of jbcom Enterprise
+
+All Arcade Cabinet projects are part of the [jbcom ecosystem](https://jbcom.github.io), created by Jon Bogaty.

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -1,0 +1,32 @@
+---
+title: Arcade Cabinet
+description: Retro-inspired games and interactive experiences from jbcom
+template: splash
+hero:
+  tagline: Retro-inspired games and interactive experiences
+  actions:
+    - text: Browse Games
+      link: /games/
+      icon: right-arrow
+    - text: View on GitHub
+      link: https://github.com/arcade-cabinet
+      icon: external
+      variant: minimal
+---
+
+import { Card, CardGrid } from '@astrojs/starlight/components';
+
+## Featured Games
+
+<CardGrid>
+  <Card title="Protocol: Silent Night" icon="star">
+    A stealth-action game with procedural elements
+  </Card>
+  <Card title="Otter River Rush" icon="rocket">
+    Fast-paced river racing adventure
+  </Card>
+</CardGrid>
+
+## Part of jbcom Enterprise
+
+Arcade Cabinet is part of the [jbcom ecosystem](https://jbcom.github.io), bringing retro-inspired gaming experiences with modern technology.

--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -2,11 +2,12 @@
   arcade-cabinet Documentation Portal
   
   BRANDING HIERARCHY:
-  1. Enterprise base (jbcom) - fonts, core colors, layout
-  2. Org theme - accent colors (inline below)
-  3. Org customizations - unique to this org
+  1. Enterprise base (jbcom.github.io) - fonts, core colors, layout
+  2. Org theme - Arcade Pink/Magenta
+  3. Org customizations - Retro arcade styling
   
   Owner: Jon Bogaty (jbcom)
+  Part of the jbcom Enterprise ecosystem
 */
 
 /* ===== LAYER 1: Enterprise Base ===== */
@@ -23,4 +24,6 @@
 
 /* ===== LAYER 3: Arcade-Specific ===== */
 /* Retro arcade game styling */
-
+.hero h1 {
+  text-shadow: 0 0 20px rgba(236, 72, 153, 0.5);
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "astro/tsconfigs/strict",
+  "compilerOptions": {
+    "strictNullChecks": true
+  }
+}


### PR DESCRIPTION
## Summary

This PR standardizes the documentation portal to inherit branding from the jbcom enterprise.

### Changes
- Import enterprise base CSS from `jbcom.github.io/enterprise-branding/starlight-base.css`
- Include arcade-cabinet-specific theme colors (Pink)
- Maintain proper owner attribution (Jon Bogaty)

### Why
- Consistent branding across jbcom ecosystem
- Jon's role as owner is preserved
- Common messaging and ethos
- Each org still has unique voice via theme colors

### Architecture
```
Enterprise (jbcom.github.io)
└── enterprise-branding/starlight-base.css  ← Shared base

Org Portal (arcade-cabinet.github.io)
└── src/styles/custom.css
    ├── @import enterprise base
    ├── Org theme (Pink)
    └── Org customizations
```

Part of: Enterprise branding standardization

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Sets up an Astro Starlight docs portal with shared jbcom branding and initial content.
> 
> - Configure `astro.config.mjs` with Starlight, `site`, social links, jbcom meta tags, sidebar (Getting Started, autogen `games/` and `packages/`), and a jbcom Enterprise links group
> - Add `src/styles/custom.css` importing jbcom enterprise base CSS and defining Arcade pink/magenta theme + minor hero styling
> - Create docs content: splash `src/content/docs/index.mdx` with featured games and `getting-started/index.md`
> - Add project scaffolding: `package.json` (Astro/Starlight deps + scripts), `tsconfig.json` (strict), and `.gitignore`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c4845904b783f3c62a1628df502d229c75ca3925. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->